### PR TITLE
Update http --brain_name option

### DIFF
--- a/pyborg/pyborg_entrypoint.py
+++ b/pyborg/pyborg_entrypoint.py
@@ -484,7 +484,7 @@ def tumblr(conf_file: str) -> None:
 
 
 @cli_base.command()
-@click.option("--brain", default="current")
+@click.option("--brain_name", default="current")
 @click.option("--host", default="localhost")
 @click.option("--port", default=2001)
 @click.option("--reloader", default=False)


### PR DESCRIPTION
This got busted in d692f888e335619a0e952531bc11a2ae2ac3932c - I got unlucky enough to bump into this right as I started toying with this bot. Let me know if `http`'s argument should be changed instead.