### PR TITLE
IRC server password support

### DIFF
--- a/pyborg/example.irc.toml
+++ b/pyborg/example.irc.toml
@@ -23,6 +23,7 @@ multiplex_server = "localhost"
 [server]
     server = "chat.freenode.net"
     port = 6697
+    password = ""
     ssl = true
     nickserv_password = "password"
     # Owner(s) nickname

--- a/pyborg/pyborg/mod/mod_irc.py
+++ b/pyborg/pyborg/mod/mod_irc.py
@@ -31,17 +31,18 @@ class Registry():
 
 
 class ModIRC(irc.bot.SingleServerIRCBot):
-    def __init__(self, my_pyborg, settings, channel=None, nickname=None, server=None, port=None, **connect_params):
+    def __init__(self, my_pyborg, settings, channel=None, nickname=None, server=None, port=None, password=None, **connect_params):
         self.settings = settings
         server = server or self.settings["server"]["server"]
         port = port or self.settings["server"]["port"]
+        password = password or self.settings["server"]["password"]
         nickname = nickname or self.settings["nickname"]
         realname = nickname or self.settings["realname"]
         if self.settings["server"]["ssl"]:
             ssl_factory = irc.connection.Factory(wrapper=ssl.wrap_socket)
-            super(ModIRC, self).__init__([(server, port)], nickname, realname, connect_factory=ssl_factory, **connect_params)
+            super(ModIRC, self).__init__([(server, port, password)], nickname, realname, connect_factory=ssl_factory, **connect_params)
         else:
-            super(ModIRC, self).__init__([(server, port)], nickname, realname, **connect_params)
+            super(ModIRC, self).__init__([(server, port, password)], nickname, realname, **connect_params)
         if not self.settings["multiplex"]:
             self.my_pyborg = my_pyborg()
 

--- a/pyborg/pyborg/mod/mod_irc.py
+++ b/pyborg/pyborg/mod/mod_irc.py
@@ -35,9 +35,10 @@ class ModIRC(irc.bot.SingleServerIRCBot):
         self.settings = settings
         server = server or self.settings["server"]["server"]
         port = port or self.settings["server"]["port"]
-        password = password or self.settings["server"]["password"]
         nickname = nickname or self.settings["nickname"]
         realname = nickname or self.settings["realname"]
+        if "password" in self.settings["server"] and self.settings["server"]["password"]:
+            password = self.settings["server"]["password"]
         if self.settings["server"]["ssl"]:
             ssl_factory = irc.connection.Factory(wrapper=ssl.wrap_socket)
             super(ModIRC, self).__init__([(server, port, password)], nickname, realname, connect_factory=ssl_factory, **connect_params)


### PR DESCRIPTION
This adds support for IRC server passwords to Pyborg and a "password" field under the [server] section of the config file.

Originally added this for myself so I could connect Pyborg to a ZNC instance (IRC bouncer).