### PR TITLE
fixed a crash when pyborg IRC gets into a channel which isn't in the configuration

### DIFF
--- a/pyborg/pyborg/mod/mod_irc.py
+++ b/pyborg/pyborg/mod/mod_irc.py
@@ -148,7 +148,7 @@ class ModIRC(irc.bot.SingleServerIRCBot):
             # check if we should reply anyways
 
             logger.debug(type(e.target))
-            if self.settings["speaking"] and self.chans[e.target.lower()]["speaking"]:
+            if self.settings["speaking"] and self.chans.get(e.target) and self.chans[e.target.lower()]["speaking"]:
                 reply_chance_inverse = 100 - self.chans[e.target.lower()]["reply_chance"]
                 logger.debug("Inverse Reply Chance = %d", reply_chance_inverse)
                 rnd = random.uniform(0, 100)  # nosec


### PR DESCRIPTION
cases i'm currently aware of in which this can happen:
* someone [SAJOIN](https://docs.inspircd.org/3/modules/sajoin/)'s the bot onto a channel which isn't defined in the configuration file
* you connect the bot to a bouncer with different or more channels than in the configuration
* potentially: channel forwards?